### PR TITLE
Bump version

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@ base_name: groonga-meatup-2015
 tags:
 - groonga
 presentation_date: 2015-11-29
-version: 2015.11.29.1
+version: 2015.11.29.2
 licenses:
 - CC BY-SA 4.0
 #slideshare_id: groonga-night-5


### PR DESCRIPTION
Because the current version has been released at RubyGems.org: https://rubygems.org/gems/rabbit-slide-hiroyuki-sato-groonga-meatup-2015/versions/2015.11.29.1
